### PR TITLE
fix: 🐛 show raid button only on stream cards

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -153,7 +153,7 @@ export default function Card({
               alt={channel.user_name}
             />
             <Box flex="1">
-              <HStack mb="3">
+              <HStack mb={isLive ? "2" : "1"}>
                 <Text
                   color={"gray.500"}
                   fontWeight={"semibold"}
@@ -166,19 +166,21 @@ export default function Card({
                   {channel.user_login}
                 </Text>
                 <Spacer />
-                <Button
-                  data-test="raid-button"
-                  size="xs"
-                  rounded="sm"
-                  onClick={copyToClipboard}
-                  bgColor="primary.500"
-                  color="secondary.800"
-                  _hover={{
-                    bgColor: "primary.700",
-                  }}
-                >
-                  Raid
-                </Button>
+                {isLive && (
+                  <Button
+                    data-test="raid-button"
+                    size="xs"
+                    rounded="sm"
+                    onClick={copyToClipboard}
+                    bgColor="primary.500"
+                    color="secondary.800"
+                    _hover={{
+                      bgColor: "primary.700",
+                    }}
+                  >
+                    Raid
+                  </Button>
+                )}
               </HStack>
 
               <Text color={"gray.100"} fontSize={"sm"} mt={-1}>


### PR DESCRIPTION
## Stream cards
![image](https://user-images.githubusercontent.com/48808846/159367881-87cf2b25-dabc-468d-a20b-3469149f1926.png)

## Vod cards
![image](https://user-images.githubusercontent.com/48808846/159367949-aa832d2f-c99f-46ad-8488-3a581dd56c34.png)


✅ Closes: #50